### PR TITLE
fix path

### DIFF
--- a/test/Horde/SyncMl/sif.phpt
+++ b/test/Horde/SyncMl/sif.phpt
@@ -10,7 +10,7 @@ class BackendStub {
 $backend = new BackendStub();
 
 // Load device handler.
-require_once __DIR__ . '/../SyncMl/Device.php';
+require_once __DIR__ . '/../../../lib/Horde/SyncMl/Device.php';
 $device = Horde_SyncMl_Device::factory('Sync4j');
 
 $data = <<<EVENT


### PR DESCRIPTION
maybe not enough to fix the tests

There was 1 failure:

1) /builddir/build/BUILD/php-horde-Horde-SyncMl-2.0.7/Horde_SyncMl-2.0.7/test/Horde/SyncMl/sif.phpt
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'<?xml version="1.0"?><appointment><ReminderSet>1</ReminderSet><IsRecurring>0</IsRecurring><BusyStatus>2</BusyStatus><AllDayEvent>0</AllDayEvent><Start>20080630T110000Z</Start><End>20080630T120000Z</End><Subject>Server02</Subject><Sensitivity>0</Sensitivity><ReminderMinutesBeforeStart>15</ReminderMinutesBeforeStart><Duration>60</Duration></appointment>
+'Deprecated: Non-static method Horde_SyncMl_Device::factory() should not be called statically in Standard input code on line 12
 
-<?xml version="1.0"?><appointment><ReminderSet>1</ReminderSet><IsRecurring>0</IsRecurring><BusyStatus>2</BusyStatus><AllDayEvent>1</AllDayEvent><Start>2008-06-30</Start><End>2008-06-30</End><Subject>Server02</Subject><Sensitivity>0</Sensitivity><ReminderMinutesBeforeStart>15</ReminderMinutesBeforeStart></appointment>
-
-<?xml version="1.0"?><appointment><ReminderSet>1</ReminderSet><IsRecurring>1</IsRecurring><BusyStatus>2</BusyStatus><AllDayEvent>0</AllDayEvent><Start>20101101T090000Z</Start><End>20101101T100000Z</End><Subject>Cinco-Lunes</Subject><Categories>Trabajo</Categories><Location>Korta</Location><Sensitivity>0</Sensitivity><Interval>1</Interval><RecurrenceType>1</RecurrenceType><DayOfWeekMask>2</DayOfWeekMask><NoEndDate>0</NoEndDate><PatternEndDate>20101130T225959Z</PatternEndDate><ReminderMinutesBeforeStart>15</ReminderMinutesBeforeStart><Duration>60</Duration></appointment>
-
-BEGIN:VCARD
-VERSION:3.0
-FN:Lastname\, Firstname
-TEL;TYPE=WORK:+61 712341234
-TEL;TYPE=CELL:+61 123123123
-EMAIL:test@domain.com
-EMAIL;TYPE=HOME:user@seconddomain.com
-NOTE:Comments\nMore comments\nAnd just a couple more
-BDAY:2008-10-18
-N:Lastname;Firstname;;;
-ADR;TYPE=WORK:;;Company\nUnit 2\, 123 St Freds Tce;Golden
-  Hills;Qld;4009;Australia
-ORG:Company
-END:VCARD'
+Fatal error: Uncaught Error: Call to a member function vevent2sif() on bool in Standard input code:42
+Stack trace:
+#0 {main}
+  thrown in Standard input code on line 42'

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
